### PR TITLE
Add owner/group/mode to the logrotate file, permissions are being randomly assigned to this file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -282,6 +282,9 @@ class supervisor(
   if $enable_logrotate == true {
     file { '/etc/logrotate.d/supervisor':
       ensure  => $file_ensure,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
       source  => 'puppet:///modules/supervisor/logrotate',
       require => Package[$supervisor::params::package],
     }


### PR DESCRIPTION
This solves

```
[staging][dal7sl][root@sentry1-s]:/var/log/supervisor# logrotate -d /etc/logrotate.d/supervisor
Ignoring /etc/logrotate.d/supervisor because the file owner is wrong (should be root).

Handling 0 logs
```