### PR TITLE
Update Modulefile to point to existing repo

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,11 +1,11 @@
 name    'jimdo-supervisor'
 version '0.2.1'
-source 'https://github.com/plathrop/puppet-module-supervisor'
+source 'https://github.com/bigcommerce/puppet-module-supervisor'
 author 'Paul Lathrop <paul@tertiusfamily.net>, Ilya Margolin <ilya@jimdo.com>, Sören Krings <soeren@jimdo.com>'
 license '2 clause BSD, see LICENSE'
 summary 'Puppet module to install and configure supervisor'
 description "Puppet module for configuring the 'supervisor' daemon control utility. Currently tested on Debian, Ubuntu, and Fedora."
-project_page 'https://github.com/plathrop/puppet-module-supervisor'
+project_page 'https://github.com/bigcommerce/puppet-module-supervisor'
 
 ## Add dependencies, if any:
 # dependency 'user/module', '>= 2.0.7'


### PR DESCRIPTION
It seems that the original repo URL for this module has been removed and now 404's.

I've updated the source and project_page URL's to point to this repo as it is still being actively maintained and should help others find the repo again if they clone it locally.